### PR TITLE
Corrected two typos to equivalences.tex

### DIFF
--- a/equivalences.tex
+++ b/equivalences.tex
@@ -46,7 +46,7 @@ In this section we exhibit a specific counterexample.
 \begin{proof}
   By assumption, $f$ is an equivalence; that is, we have $e:\isequiv(f)$ and so $(f,e):\eqv A B$.
   By univalence, $\idtoeqv:(A=B) \to (\eqv A B)$ is an equivalence, so we may assume that $(f,e)$ is of the form $\idtoeqv(p)$ for some $p:A=B$.
-  Then by path induction, we may assume $p$ is $\refl{A}$, in which case $\idtoeqv(p)$ is $\idfunc[A]$.
+  Then by path induction, we may assume $p$ is $\refl{A}$, in which case $\fst(\idtoeqv(p))$ is $\idfunc[A]$.
   Thus we are reduced to proving $\eqv{\qinv(\idfunc[A])}{(\prd{x:A}(x=x))}$.
   Now by definition we have
   \[ \qinv(\idfunc[A]) \jdeq
@@ -954,7 +954,7 @@ Then $\prd{x:A}P(x)$ is a retract of $\hfiber{\alpha}{\idfunc[A]}$. As a consequ
 \begin{proof}
 Define the functions
 \begin{align*}
-  \varphi &: \tprd{x:A}P(x)\to\hfiber{\alpha}{\idfunc[A]},\\
+  \varphi &: (\tprd{x:A}P(x))\to\hfiber{\alpha}{\idfunc[A]},\\
   \varphi(f) &\defeq (\lam{x} (x,f(x)),\refl{\idfunc[A]}),
 \intertext{and}
   \psi &: \hfiber{\alpha}{\idfunc[A]}\to \tprd{x:A}P(x), \\


### PR DESCRIPTION
Line 49: took into account the fact that an equivalence is a pair (f,e).

Line 957: added a pair of parenthesis.
